### PR TITLE
implement detailsView with d3graphView

### DIFF
--- a/app/assets/stylesheets/custom.less
+++ b/app/assets/stylesheets/custom.less
@@ -70,6 +70,11 @@ svg {
   background:@navy;
 }
 
+.details-container {
+  position:relative;
+  top: 60px;
+}
+
 // Overriding Bootstrap defaults
 
 .navbar {

--- a/app/models/GraphModel.coffee
+++ b/app/models/GraphModel.coffee
@@ -10,6 +10,8 @@ define ['backbone', 'cs!models/NodeModel','cs!models/ConnectionModel'], (Backbon
       @nodes = new NodeCollection()
       @connections = new ConnectionCollection()
 
+      @selectedNode = {}
+
     putNode: (name) ->
       console.log "Added node with name #{name}"
       @nodes.add {'name': name}
@@ -17,3 +19,7 @@ define ['backbone', 'cs!models/NodeModel','cs!models/ConnectionModel'], (Backbon
     putConnection: (name) ->
       console.log "Added connection with name #{name}"
       @connections.add {'name': name}
+
+    selectNode: (node) ->
+      @selectedNode = node
+      @trigger "select:node", node

--- a/app/public/index.jade
+++ b/app/public/index.jade
@@ -14,5 +14,6 @@ block content
         button.btn.btn-default(type="submit")
           i.fa.fa-plus
       button#sidebar-toggle.btn.btn-default.navbar-right Toggle Sidebar
+    .details-container
 
   #sidebar

--- a/app/views/DetailsView.coffee
+++ b/app/views/DetailsView.coffee
@@ -5,13 +5,11 @@ define ['jquery', 'underscore', 'backbone', 'text!templates/details_box.html'],
       el: $ '#graph'
       viewBox: $ '#main-container'
 
-      events:
-        'click .node': 'update'
+      initialize: ->
+        @model.on 'select:node', (datum) => 
+          @update datum
       
-      update: (clickedDOM) ->
+      update: (clickedNode) ->
         $(".details-container").empty()
-
-        clickedID = $(clickedDOM.currentTarget).data("node-id")
-        clickedNode = @model.nodes.get(clickedID)
 
         $(".details-container").append _.template(detailsTemplate, clickedNode)

--- a/app/views/GraphView.coffee
+++ b/app/views/GraphView.coffee
@@ -66,6 +66,10 @@ define ['jquery', 'underscore', 'backbone', 'd3', 'text!templates/node.html',
           .text((d) -> d.get('name'))
         nodeEnter.append("circle")
           .attr("r", 25)
+        nodeEnter.on "click", (datum, index) =>
+          @model.selectNode datum
+          @trigger "node:click", datum
+
 
         tick = ->
           connection


### PR DESCRIPTION
Issue: https://github.com/willzeng/rhizi-client/issues/18

This is just a functionality commit.  The DetailsView template needs to be styled and the minimal css included here is just to make it viewable.

I'll also readily say that there are a lot of ways that this could have been implemented.  The other main option could have been to have a data attribute on the nodes and then have jquery look for that.  This seemed redundant with d3's abilities to pass data around so (since the graph has to be d3 anyway) I went with the d3 option as it works clearly.

This also made it possible for me to implement things to keep the details view and graph view from depending on each other in any way, which is an improvement over how WikiNets worked.

@vpontis @davidfurlong 
