### PR TITLE
#smallBugs on requirejs shim for bbModal and typo in MenuView dependencies

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -27,6 +27,9 @@ requirejs.config({
     },
     'bootstrap': {
       deps: ['jquery']
+    },
+    'bb-modal': {
+      deps: ['underscore', 'jquery', 'backbone']
     }
   },
   packages: [{

--- a/app/views/MenuView.coffee
+++ b/app/views/MenuView.coffee
@@ -1,7 +1,7 @@
 define ['jquery', 'underscore', 'backbone', 'bloodhound', 'typeahead', 'bootstrap',
  'bb-modal', 'text!templates/new_doc_modal.html', 'text!templates/open_doc_modal.html',
   'cs!models/DocumentModel', 'cs!models/WorkspaceModel'],
-  ($, _, Backbone, Bloodhound, typeahead, bootsrap, bbModal, newDocTemplate, openDocTemplate, DocumentModel) ->
+  ($, _, Backbone, Bloodhound, typeahead, bootstrap, bbModal, newDocTemplate, openDocTemplate, DocumentModel) ->
     class DocumentCollection extends Backbone.Collection
       model: DocumentModel
       url: 'documents'


### PR DESCRIPTION
This is a fix missing requirejs shim for bbModal and typo in MenuView dependencies.

Noticed this error when working with the landing page.
