### PR TITLE
fix bottom alignment of icons

### DIFF
--- a/app/assets/stylesheets/custom.less
+++ b/app/assets/stylesheets/custom.less
@@ -178,7 +178,7 @@ input[type="text"]:-ms-input-placeholder { /* Internet Explorer 10+ */
 
 #zoom-controls {
   position: absolute;
-  bottom: 40px;
+  bottom: 80px;
   left: 15px;
 }
 
@@ -202,7 +202,7 @@ input[type="text"]:-ms-input-placeholder { /* Internet Explorer 10+ */
   font-size: 26pt;
   color: lightgray;
   position: absolute;
-  bottom: 40px;
+  bottom: 80px;
   left: 70px;
   padding-top:12px;
   text-align: center;
@@ -267,7 +267,7 @@ input[type="text"]:-ms-input-placeholder { /* Internet Explorer 10+ */
 
 .toolbar.bottom {
   position: absolute;
-  bottom: 40px;
+  bottom: 80px;
 }
 
 .controls {


### PR DESCRIPTION
![screenshot 2014-07-13 23 42 30](https://cloud.githubusercontent.com/assets/1319079/3567756/5c379ee2-0b22-11e4-9376-5e09c8e24bba.png)

My screen was looking like the attached image before, the bottom of the trash can, zoom buttons, and share button were cutoff. I don't know if you guys had the same problem. It's not the best solution (we should use classes instead of setting the same value in three different places) but it works. Let me know if you guys weren't having the same problem.
