### PR TITLE
Firefox bug fix + mouseover below fix

### DIFF
--- a/app/assets/stylesheets/custom.less
+++ b/app/assets/stylesheets/custom.less
@@ -12,7 +12,6 @@
 
 .node {
   transition: opacity .5s ease-in-out;
-  cursor: pointer;
 }
 
 .node.dim {
@@ -37,12 +36,16 @@
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   hyphens: auto;
+
+  height: auto;
 }
 
 .node-info-body, .connection-info-body {
   background: white;
   display: none;
   color: gray;
+  cursor: pointer;
+  height: auto;
 }
 
 .pad {
@@ -69,6 +72,7 @@
   font: 15px sans-serif;
   text-anchor: middle;
   fill: #fff;
+  cursor: pointer;
   text-shadow: 0 1px 0 #333, 1px 0 0 #333, 0 -1px 0 #333, -1px 0 0 #333;
 }
 

--- a/app/views/DataTooltip.coffee
+++ b/app/views/DataTooltip.coffee
@@ -4,8 +4,7 @@ define ['jquery', 'd3',  'underscore', 'backbone', 'text!templates/data_tooltip.
       el: $ '#graph'
 
       events:
-        'mousemove svg' : 'trackCursor'
-        'mouseover .node' : 'showToolTip'
+        'mouseover .node-title-body' : 'showToolTip'
         'mouseover .connection' : 'showToolTip'
 
       initialize: ->
@@ -34,14 +33,9 @@ define ['jquery', 'd3',  'underscore', 'backbone', 'text!templates/data_tooltip.
             @model.highlight(nodesToHL, connectionsToHL)
           , 600
 
-      trackCursor: (event) ->
-        $(".data-tooltip-container")
-          .css('left',event.clientX)
-          .css('top',event.clientY-20)
-
       showToolTip: (event) ->
         @isHoveringANode = setTimeout( () =>
-          $(event.currentTarget).find('.node-info-body').addClass('shown')
+          $(event.currentTarget).closest('.node').find('.node-info-body').addClass('shown')
           $(event.currentTarget).find('.connection-info-body').addClass('shown')
         , 600)
 

--- a/app/views/GraphView.coffee
+++ b/app/views/GraphView.coffee
@@ -216,13 +216,13 @@ define ['jquery', 'underscore', 'backbone', 'd3', 'text!templates/d3_defs.html'
           el = $(t).find('.node-title-body')
           left = el.width()/2+parseInt(el.css('border-left-width'),10)
           top = el.height()/2+parseInt(el.css('border-bottom-width'),10)
+
           $(t)
             .attr('y', - top)
-          dim = t.getBBox()
-          
+
           info = $(t).parent().find('.node-info')
           info
-            .attr('x',dim.x-left)
+            .attr('x',-left)
             .attr('y',top)
 
         # delete unmatching elements


### PR DESCRIPTION
Firefox was displaying .node-info-body as height: 100%; by default and chrome was displaying height: auto; by default. The second is preferred.

Mouseover below fix:
We were doing mouseovers on .node but this is a taller element than .node-title-body
