### PR TITLE
ignore datatooltip mouse events when dragging

### DIFF
--- a/app/views/DataTooltip.coffee
+++ b/app/views/DataTooltip.coffee
@@ -44,9 +44,10 @@ define ['jquery', 'd3',  'underscore', 'backbone'],
             @model.highlight(nodesToHL, connectionsToHL)
           , 600
 
-      showToolTip: (event) ->
-        $(event.currentTarget).closest('.node').find('.node-info-body').addClass('shown')
-        $(event.currentTarget).find('.connection-info-body').addClass('shown')
+      showToolTip: (event) =>
+        if !(@ignoreMouse)
+          $(event.currentTarget).closest('.node').find('.node-info-body').addClass('shown')
+          $(event.currentTarget).find('.connection-info-body').addClass('shown')
 
       emptyTooltip: () ->
         $('.node-info-body').removeClass('shown')


### PR DESCRIPTION
Sometimes when dragging your mouse will leave the node and trigger unnecessary dataTooltip events on mouseout and mouse enter.  This PR aims to ignore these spurious events.

@davidfurlong @vpontis  is ready for review and merge with one approval.
