### PR TITLE
make tags linkable and routable to via client-side urls

### DIFF
--- a/app/routes/routes.coffee
+++ b/app/routes/routes.coffee
@@ -14,7 +14,13 @@ define ['jquery', 'underscore', 'backbone', 'cs!models/NodeModel', 'cs!models/Co
         @sidebarView = new SideBarView model: @workspaceModel
         @menuView = new MenuView model: @workspaceModel
         @shareView = new ShareView model: @workspaceModel
+
         @shareView.on "save:workspace", (workspaceId) => @navigate ""+workspaceId
+        @graphView.on "tag:click", (tag) =>
+          @workspaceModel.filterModel.set "node_tags", [tag]
+          @workspaceModel.filter()
+          @searchView.search {value:tag, type:"tag"}
+          @navigate "search/"+tag
 
         window.gm = @workspaceModel
         Backbone.history.start()
@@ -22,6 +28,7 @@ define ['jquery', 'underscore', 'backbone', 'cs!models/NodeModel', 'cs!models/Co
       routes:
         '': 'home'
         '(:id)': 'workspace'
+        'search/:tag': 'loadByTag'
 
       home: () =>
         @setDoc()
@@ -63,6 +70,11 @@ define ['jquery', 'underscore', 'backbone', 'cs!models/NodeModel', 'cs!models/Co
         @workspaceModel.getTagNames (tags) =>
           @workspaceModel.filterModel.addInitialTags tags
           @workspaceModel.filterModel.addNodeTags tags
+
+      loadByTag: (tag) ->
+        @setDoc()
+        @searchView.search {value:tag, type:"tag"}
+        $('.loading-container').remove()
 
       randomPopulate: ->
         num = Math.round(3+Math.random()*15)

--- a/app/templates/data_tooltip.html
+++ b/app/templates/data_tooltip.html
@@ -9,7 +9,8 @@
 <% if((attributes.description != null && attributes.description != "") || _.some(attributes.tags)){ %>
   <div class="pad">
     <div>
-    <%= attributes.description %>
+    <% linkified = attributes.description.replace(/#(\S*)/g,'<a class="tag-link" data-tag=$1 href="">#$1</a>'); %>
+    <%= linkified %>
     </div>
     <% if(_.some(attributes.tags)){ %>
       <div>

--- a/app/views/DataTooltip.coffee
+++ b/app/views/DataTooltip.coffee
@@ -67,7 +67,6 @@ define ['jquery', 'd3',  'underscore', 'backbone'],
       expandNode: (event) ->
         expandId = parseInt $(event.currentTarget).attr("data-id")
         expandedNode = @model.nodes.findWhere {_id:expandId}
-        window.nc = expandedNode
         expandedNode.getNeighbors (neighbors) =>
           for node in neighbors
             newNode = new expandedNode.constructor node

--- a/app/views/GraphView.coffee
+++ b/app/views/GraphView.coffee
@@ -255,6 +255,12 @@ define ['jquery', 'underscore', 'backbone', 'd3', 'cs!views/svgDefs'
         # delete unmatching elements
         node.exit().remove()
 
+        # set-up clickable tags
+        $('.tag-link').on "click", (e) =>
+          e.preventDefault()
+          tag = $(e.currentTarget).attr('data-tag')
+          @trigger 'tag:click', tag
+
         tick = =>
           connection.selectAll("line")
             .attr("x1", (d) => @model.getSourceOf(d).x-(@nodeBoxWidth/2+10))


### PR DESCRIPTION
Addresses: https://github.com/willzeng/graphdocs/issues/367

Works as advertised.  The best thing about implementing this via client-side routing is that after you do a search you can quickly go back by using your browsers back button.

@davidfurlong @vpontis This is ready for merge.
