### PR TITLE
Declare underscore version 1.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "caret.js": "~0.1.0",
     "targeted-atwho": "~0.5.2",
     "twitter-text": "~1.9.4",
-    "jQuery-linkify": "~1.1.7"
+    "jQuery-linkify": "~1.1.7",
+    "underscore": "1.6.0"
   },
   "devDependencies": {
     "jasmine": "~2.0.0"


### PR DESCRIPTION
We hadn't included an explicit underscore dependency and underscore released [version 1.7.0](http://underscorejs.org/#changelog) four days ago which changes how [templates](http://underscorejs.org/#template) work (and breaks out implementation).

It wouldn't be difficult to upgrade, but I don't see any reason to at present, so a better fix is to add an explicit dependency for 1.6.0  We can update later if we choose.

@davidfurlong @vpontis this is ready for merge
