### PR TITLE
Conn search

### DIFF
--- a/app/models/DocumentModel.coffee
+++ b/app/models/DocumentModel.coffee
@@ -49,6 +49,10 @@ define ['backbone', 'b-iobind', 'b-iosync', 'socket-io'], (Backbone, iobind, ios
       $.get @url() + '/getNodeByName', {name: name}, (node) =>
         cb node
 
+    getConnsByName: (name, cb) ->
+      $.get @url() + '/getConnsByName', {name: name}, (conns) =>
+        cb conns
+
     getNodesByTag: (tag, cb) ->
       $.get @url() + '/getNodesByTag', {tag: tag}, (nodes) =>
         cb nodes

--- a/app/models/WorkspaceModel.coffee
+++ b/app/models/WorkspaceModel.coffee
@@ -198,6 +198,9 @@ define ['jquery', 'backbone', 'cs!models/NodeModel','cs!models/ConnectionModel',
       getNodesByTag: (tag, cb) ->
         @documentModel.getNodesByTag(tag, cb)
 
+      getConnsByName: (name, cb) ->
+        @documentModel.getConnsByName(name, cb)
+
       # Syncing Workspaces
       sync: (method, model, options) ->
         options = options || {}

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -60,9 +60,10 @@ router.put      '/document/:docId/connections/:id',   connections.update
 router.delete   '/document/:docId/connections/:id',   connections.destroy
 
 # Search
-router.get      '/document/:docId/nodes/names',       search.getNodeNames
-router.get      '/document/:docId/getNodeByName',     search.getNodeByName
-router.get      '/document/:docId/getNodesByTag',     search.getNodesByTag
-router.get      '/document/:docId/tags',              search.getTagNames
+router.get      '/document/:docId/nodes/names',        search.getNodeNames
+router.get      '/document/:docId/getNodeByName',      search.getNodeByName
+router.get      '/document/:docId/getNodesByTag',      search.getNodesByTag
+router.get      '/document/:docId/getConnsByName',     search.getConnsByName
+router.get      '/document/:docId/tags',               search.getTagNames
 
 module.exports = router


### PR DESCRIPTION
Fixes #235 

The interaction here could be changed, but I tried to go with what seemed simplest.

When you type in the search box, it matches with connection types that are in the graphdoc.  Should you choose a connection type all connections of that type (along with their source and target) will be added to the workspace.  The graph then centers on one of them.

@davidfurlong check it out for merge.
