### PR TITLE
move resetadd to happen without waiting for the new node to be saved to ...

### DIFF
--- a/app/views/AddNodeView.coffee
+++ b/app/views/AddNodeView.coffee
@@ -159,7 +159,7 @@ define ['jquery', 'underscore', 'backbone', 'cs!models/WorkspaceModel', 'cs!mode
                   targetNode.fetch()
                 @model.putConnection connection
 
-            @resetAdd()
+          @resetAdd()
         else
           $('input', @el).attr('placeholder', node.validate())
 


### PR DESCRIPTION
...the server

Probably relates to #607 though I am not sure if it fixes it.

In any case, we should implement this.  @davidfurlong this is mergable
