### PR TITLE
lock mongoose to more stable 3.8.x versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jade": "1.3.1",
     "less-middleware": "~0.2.1-beta",
     "method-override": "^2.2.0",
-    "mongoose": "^3.8.16",
+    "mongoose": "~3.8.16",
     "morgan": "^1.3.0",
     "neo4j": "~1.1.0",
     "nodemailer": "0.7.1",


### PR DESCRIPTION
When running `npm install`, I got mongoose 3.9.7, which upon startup (`./bin/www`), issues loud warnings:

```
##############################################################
#
#   !!! MONGOOSE WARNING !!!
#
#   This is an UNSTABLE release of Mongoose.
#   Unstable releases are available for preview/testing only.
#   DO NOT run this in production.
#
##############################################################
```

Changing to the more conservative tilde syntax locks the version to the non-warning-issuing 3.8.x versions.
