### PR TITLE
Simplify server config; compile prestart

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: sh server.sh

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ How to Run Locally
 - Neo4j Server 2.1.3 <= Version <= 2.2.0 Required
 At time of writing 2.1.8 is most current and can be downloaded from: [Download](http://neo4j.com/download/other-releases/)
 - Clone this repo
-- `npm install` should:
-  - install your node modules in the `node_modules/` folder
-  - install your front end libraries in the `assets/libs/` folder, using bower
+- `npm install` should install your node modules in the `node_modules/` folder.
+- `npm install -g bower` should install bower to your global path.
+- `bower install` should install your front end models in the `assets/libs/` folder.
 
 Then you should be able to run `./bin/www` to get the server running at `localhost:3000/`
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ How to Run Locally
 - Neo4j Server 2.1.3 <= Version <= 2.2.0 Required
 At time of writing 2.1.8 is most current and can be downloaded from: [Download](http://neo4j.com/download/other-releases/)
 - Clone this repo
-- `npm install` should install your node modules in the `node_modules/` folder.
-- `npm install -g bower` should install bower to your global path.
-- `bower install` should install your front end models in the `assets/libs/` folder.
+- `npm install` should:
+  - install your node modules in the `node_modules/` folder
+  - install your front end libraries in the `assets/libs/` folder, using bower
 
 Then you should be able to run `./bin/www` to get the server running at `localhost:3000/`
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+node_modules/.bin/lessc -x app/assets/stylesheets/general.less > app/assets/stylesheets/general.css
+node_modules/.bin/lessc -x app/assets/stylesheets/graph.less > app/assets/stylesheets/graph.css
+node_modules/.bin/lessc -x app/assets/stylesheets/index-logged-in.less > app/assets/stylesheets/index-logged-in.css
+node_modules/.bin/lessc -x app/assets/stylesheets/index.less > app/assets/stylesheets/index.css
+node_modules/.bin/lessc -x app/assets/stylesheets/login.less > app/assets/stylesheets/login.css
+node_modules/.bin/lessc -x app/assets/stylesheets/mobile.less > app/assets/stylesheets/mobile.css
+node_modules/.bin/lessc -x app/assets/stylesheets/nav.less > app/assets/stylesheets/nav.css
+node_modules/.bin/lessc -x app/assets/stylesheets/profile.less > app/assets/stylesheets/profile.css
+node_modules/.bin/r.js -o app/build.js
+node_modules/.bin/r.js -o app/build-css.js

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "requirejs": "~2.1.15"
   },
   "scripts": {
+    "postinstall": "rm -rf app/assets/libs && bower install",
     "start": "lessc -x app/assets/stylesheets/general.less > app/assets/stylesheets/general.css; lessc -x app/assets/stylesheets/graph.less > app/assets/stylesheets/graph.css; lessc -x app/assets/stylesheets/index-logged-in.less > app/assets/stylesheets/index-logged-in.css; lessc -x app/assets/stylesheets/index.less > app/assets/stylesheets/index.css; lessc -x app/assets/stylesheets/login.less > app/assets/stylesheets/login.css; lessc -x app/assets/stylesheets/mobile.less > app/assets/stylesheets/mobile.css; lessc -x app/assets/stylesheets/nav.less > app/assets/stylesheets/nav.css; lessc -x app/assets/stylesheets/profile.less > app/assets/stylesheets/profile.css; node_modules/requirejs/bin/r.js -o app/build.js; node_modules/requirejs/bin/r.js -o app/build-css.js; node ./bin/www"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "requirejs": "~2.1.15"
   },
   "scripts": {
-    "prestart": "rm -rf app/assets/libs && bower install && bin/compile",
+    "postinstall": "rm -rf app/assets/libs && bower install && bin/compile",
     "start": "node bin/www"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
   "devDependencies": {
     "coffeelint": "~1.3.0",
     "grunt": "~0.4.4",
-    "grunt-lesslint": "~1.1.2",
     "grunt-coffeelint": "0.0.10",
+    "grunt-lesslint": "~1.1.2",
+    "less": "^2.5.0",
     "requirejs": "~2.1.15"
   },
   "scripts": {
-    "postinstall": "rm -rf app/assets/libs && bower install",
-    "start": "lessc -x app/assets/stylesheets/general.less > app/assets/stylesheets/general.css; lessc -x app/assets/stylesheets/graph.less > app/assets/stylesheets/graph.css; lessc -x app/assets/stylesheets/index-logged-in.less > app/assets/stylesheets/index-logged-in.css; lessc -x app/assets/stylesheets/index.less > app/assets/stylesheets/index.css; lessc -x app/assets/stylesheets/login.less > app/assets/stylesheets/login.css; lessc -x app/assets/stylesheets/mobile.less > app/assets/stylesheets/mobile.css; lessc -x app/assets/stylesheets/nav.less > app/assets/stylesheets/nav.css; lessc -x app/assets/stylesheets/profile.less > app/assets/stylesheets/profile.css; node_modules/requirejs/bin/r.js -o app/build.js; node_modules/requirejs/bin/r.js -o app/build-css.js; node ./bin/www"
+    "prestart": "rm -rf app/assets/libs && bower install && bin/compile",
+    "start": "node bin/www"
   },
   "repository": {
     "type": "git",

--- a/server.sh
+++ b/server.sh
@@ -1,2 +1,0 @@
-bower install
-npm start


### PR DESCRIPTION
(Hopefully) simplified and improved the npm / heroku setup.

Notes:
- Heroku will run "npm start" if no Procfile is present
- `set -e` means that if any command fails, execution stops (app fails to start)
- Add `less` to dev dependencies
- Move asset compilation to bin/compile
- Added `rm -rf app/assets/libs` because repeated `bower install` (on my machine at least) caused errors

Upshot: everything should work the same as before, except that `npm start` now runs `bower install` instead of the Procfile doing it.  `lessc` should now work on Heroku, which it was not for me previously.
