### PR TITLE
Adds necessary two arguments to the app.use session constructor

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -51,6 +51,8 @@ app.use session
     ttl: 6048000 # ten weeks
   cookie :
     maxAge : 6048000 # ten weeks
+  saveUnitialized: false
+  resave: true
 
 app.use passport.initialize()
 app.use passport.session() # persistent login sessions

--- a/app.coffee
+++ b/app.coffee
@@ -51,7 +51,7 @@ app.use session
     ttl: 6048000 # ten weeks
   cookie :
     maxAge : 6048000 # ten weeks
-  saveUnitialized: false
+  saveUninitialized: false
   resave: true
 
 app.use passport.initialize()


### PR DESCRIPTION
See https://github.com/expressjs/session#options for reference

solves the two deprecated warnings on start
